### PR TITLE
Fix some minor isuue to work with keras2/tensorflow2

### DIFF
--- a/keras_frcnn/FixedBatchNormalization.py
+++ b/keras_frcnn/FixedBatchNormalization.py
@@ -23,20 +23,20 @@ class FixedBatchNormalization(Layer):
         self.input_spec = [InputSpec(shape=input_shape)]
         shape = (input_shape[self.axis],)
 
-        self.gamma = self.add_weight(shape,
+        self.gamma = self.add_weight(shape=shape,
                                      initializer=self.gamma_init,
                                      regularizer=self.gamma_regularizer,
                                      name='{}_gamma'.format(self.name),
                                      trainable=False)
-        self.beta = self.add_weight(shape,
+        self.beta = self.add_weight(shape=shape,
                                     initializer=self.beta_init,
                                     regularizer=self.beta_regularizer,
                                     name='{}_beta'.format(self.name),
                                     trainable=False)
-        self.running_mean = self.add_weight(shape, initializer='zero',
+        self.running_mean = self.add_weight(shape=shape, initializer='zero',
                                             name='{}_running_mean'.format(self.name),
                                             trainable=False)
-        self.running_std = self.add_weight(shape, initializer='one',
+        self.running_std = self.add_weight(shape=shape, initializer='one',
                                            name='{}_running_std'.format(self.name),
                                            trainable=False)
 

--- a/keras_frcnn/RoiPoolingConv.py
+++ b/keras_frcnn/RoiPoolingConv.py
@@ -26,7 +26,7 @@ class RoiPoolingConv(Layer):
     '''
     def __init__(self, pool_size, num_rois, **kwargs):
 
-        self.dim_ordering = K.image_dim_ordering()
+        self.dim_ordering = K.common.image_dim_ordering()
         assert self.dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
 
         self.pool_size = pool_size
@@ -102,7 +102,7 @@ class RoiPoolingConv(Layer):
                 w = K.cast(w, 'int32')
                 h = K.cast(h, 'int32')
 
-                rs = tf.image.resize_images(img[:, y:y+h, x:x+w, :], (self.pool_size, self.pool_size))
+                rs = tf.image.resize(img[:, y:y+h, x:x+w, :], (self.pool_size, self.pool_size))
                 outputs.append(rs)
 
         final_output = K.concatenate(outputs, axis=0)

--- a/keras_frcnn/losses.py
+++ b/keras_frcnn/losses.py
@@ -1,7 +1,7 @@
 from keras import backend as K
 from keras.objectives import categorical_crossentropy
 
-if K.image_dim_ordering() == 'tf':
+if K.common.image_dim_ordering() == 'tf':
 	import tensorflow as tf
 
 lambda_rpn_regr = 1.0
@@ -15,7 +15,7 @@ epsilon = 1e-4
 
 def rpn_loss_regr(num_anchors):
 	def rpn_loss_regr_fixed_num(y_true, y_pred):
-		if K.image_dim_ordering() == 'th':
+		if K.common.image_dim_ordering() == 'th':
 			x = y_true[:, 4 * num_anchors:, :, :] - y_pred
 			x_abs = K.abs(x)
 			x_bool = K.less_equal(x_abs, 1.0)
@@ -34,7 +34,7 @@ def rpn_loss_regr(num_anchors):
 
 def rpn_loss_cls(num_anchors):
 	def rpn_loss_cls_fixed_num(y_true, y_pred):
-		if K.image_dim_ordering() == 'tf':
+		if K.common.image_dim_ordering() == 'tf':
 			return lambda_rpn_class * K.sum(y_true[:, :, :, :num_anchors] * K.binary_crossentropy(y_pred[:, :, :, :], y_true[:, :, :, num_anchors:])) / K.sum(epsilon + y_true[:, :, :, :num_anchors])
 		else:
 			return lambda_rpn_class * K.sum(y_true[:, :num_anchors, :, :] * K.binary_crossentropy(y_pred[:, :, :, :], y_true[:, num_anchors:, :, :])) / K.sum(epsilon + y_true[:, :num_anchors, :, :])

--- a/keras_frcnn/resnet.py
+++ b/keras_frcnn/resnet.py
@@ -17,7 +17,7 @@ from keras_frcnn.RoiPoolingConv import RoiPoolingConv
 from keras_frcnn.FixedBatchNormalization import FixedBatchNormalization
 
 def get_weight_path():
-    if K.image_dim_ordering() == 'th':
+    if K.common.image_dim_ordering() == 'th':
         return 'resnet50_weights_th_dim_ordering_th_kernels_notop.h5'
     else:
         return 'resnet50_weights_tf_dim_ordering_tf_kernels.h5'
@@ -39,7 +39,7 @@ def identity_block(input_tensor, kernel_size, filters, stage, block, trainable=T
 
     nb_filter1, nb_filter2, nb_filter3 = filters
     
-    if K.image_dim_ordering() == 'tf':
+    if K.common.image_dim_ordering() == 'tf':
         bn_axis = 3
     else:
         bn_axis = 1
@@ -68,7 +68,7 @@ def identity_block_td(input_tensor, kernel_size, filters, stage, block, trainabl
     # identity block time distributed
 
     nb_filter1, nb_filter2, nb_filter3 = filters
-    if K.image_dim_ordering() == 'tf':
+    if K.common.image_dim_ordering() == 'tf':
         bn_axis = 3
     else:
         bn_axis = 1
@@ -95,7 +95,7 @@ def identity_block_td(input_tensor, kernel_size, filters, stage, block, trainabl
 def conv_block(input_tensor, kernel_size, filters, stage, block, strides=(2, 2), trainable=True):
 
     nb_filter1, nb_filter2, nb_filter3 = filters
-    if K.image_dim_ordering() == 'tf':
+    if K.common.image_dim_ordering() == 'tf':
         bn_axis = 3
     else:
         bn_axis = 1
@@ -127,7 +127,7 @@ def conv_block_td(input_tensor, kernel_size, filters, stage, block, input_shape,
     # conv block time distributed
 
     nb_filter1, nb_filter2, nb_filter3 = filters
-    if K.image_dim_ordering() == 'tf':
+    if K.common.image_dim_ordering() == 'tf':
         bn_axis = 3
     else:
         bn_axis = 1
@@ -156,7 +156,7 @@ def conv_block_td(input_tensor, kernel_size, filters, stage, block, input_shape,
 def nn_base(input_tensor=None, trainable=False):
 
     # Determine proper input shape
-    if K.image_dim_ordering() == 'th':
+    if K.common.image_dim_ordering() == 'th':
         input_shape = (3, None, None)
     else:
         input_shape = (None, None, 3)
@@ -169,7 +169,7 @@ def nn_base(input_tensor=None, trainable=False):
         else:
             img_input = input_tensor
 
-    if K.image_dim_ordering() == 'tf':
+    if K.common.image_dim_ordering() == 'tf':
         bn_axis = 3
     else:
         bn_axis = 1

--- a/keras_frcnn/vgg.py
+++ b/keras_frcnn/vgg.py
@@ -20,7 +20,7 @@ from keras_frcnn.RoiPoolingConv import RoiPoolingConv
 
 
 def get_weight_path():
-    if K.image_dim_ordering() == 'th':
+    if K.common.image_dim_ordering() == 'th':
         print('pretrained weights not available for VGG with theano backend')
         return
     else:
@@ -37,7 +37,7 @@ def nn_base(input_tensor=None, trainable=False):
 
 
     # Determine proper input shape
-    if K.image_dim_ordering() == 'th':
+    if K.common.image_dim_ordering() == 'th':
         input_shape = (3, None, None)
     else:
         input_shape = (None, None, 3)
@@ -50,7 +50,7 @@ def nn_base(input_tensor=None, trainable=False):
         else:
             img_input = input_tensor
 
-    if K.image_dim_ordering() == 'tf':
+    if K.common.image_dim_ordering() == 'tf':
         bn_axis = 3
     else:
         bn_axis = 1

--- a/measure_map.py
+++ b/measure_map.py
@@ -149,7 +149,7 @@ print(class_mapping)
 class_to_color = {class_mapping[v]: np.random.randint(0, 255, 3) for v in class_mapping}
 C.num_rois = int(options.num_rois)
 
-if K.image_dim_ordering() == 'th':
+if K.common.image_dim_ordering() == 'th':
 	input_shape_img = (3, None, None)
 	input_shape_features = (1024, None, None)
 else:
@@ -196,13 +196,13 @@ for idx, img_data in enumerate(test_imgs):
 
 	X, fx, fy = format_img(img, C)
 
-	if K.image_dim_ordering() == 'tf':
+	if K.common.image_dim_ordering() == 'tf':
 		X = np.transpose(X, (0, 2, 3, 1))
 
 	# get the feature maps and output from the RPN
 	[Y1, Y2, F] = model_rpn.predict(X)
 
-	R = roi_helpers.rpn_to_roi(Y1, Y2, C, K.image_dim_ordering(), overlap_thresh=0.7)
+	R = roi_helpers.rpn_to_roi(Y1, Y2, C, K.common.image_dim_ordering(), overlap_thresh=0.7)
 
 	# convert from (x1,y1,x2,y2) to (x,y,w,h)
 	R[:, 2] -= R[:, 0]

--- a/test_frcnn.py
+++ b/test_frcnn.py
@@ -106,7 +106,7 @@ if C.network == 'resnet50':
 elif C.network == 'vgg':
 	num_features = 512
 
-if K.image_dim_ordering() == 'th':
+if K.common.image_dim_ordering() == 'th':
 	input_shape_img = (3, None, None)
 	input_shape_features = (num_features, None, None)
 else:
@@ -158,14 +158,14 @@ for idx, img_name in enumerate(sorted(os.listdir(img_path))):
 
 	X, ratio = format_img(img, C)
 
-	if K.image_dim_ordering() == 'tf':
+	if K.common.image_dim_ordering() == 'tf':
 		X = np.transpose(X, (0, 2, 3, 1))
 
 	# get the feature maps and output from the RPN
 	[Y1, Y2, F] = model_rpn.predict(X)
 	
 
-	R = roi_helpers.rpn_to_roi(Y1, Y2, C, K.image_dim_ordering(), overlap_thresh=0.7)
+	R = roi_helpers.rpn_to_roi(Y1, Y2, C, K.common.image_dim_ordering(), overlap_thresh=0.7)
 
 	# convert from (x1,y1,x2,y2) to (x,y,w,h)
 	R[:, 2] -= R[:, 0]

--- a/train_frcnn.py
+++ b/train_frcnn.py
@@ -107,10 +107,10 @@ print('Num train samples {}'.format(len(train_imgs)))
 print('Num val samples {}'.format(len(val_imgs)))
 
 
-data_gen_train = data_generators.get_anchor_gt(train_imgs, classes_count, C, nn.get_img_output_length, K.image_dim_ordering(), mode='train')
-data_gen_val = data_generators.get_anchor_gt(val_imgs, classes_count, C, nn.get_img_output_length,K.image_dim_ordering(), mode='val')
+data_gen_train = data_generators.get_anchor_gt(train_imgs, classes_count, C, nn.get_img_output_length, K.common.image_dim_ordering(), mode='train')
+data_gen_val = data_generators.get_anchor_gt(val_imgs, classes_count, C, nn.get_img_output_length,K.common.image_dim_ordering(), mode='val')
 
-if K.image_dim_ordering() == 'th':
+if K.common.image_dim_ordering() == 'th':
 	input_shape_img = (3, None, None)
 else:
 	input_shape_img = (None, None, 3)
@@ -184,7 +184,7 @@ for epoch_num in range(num_epochs):
 
 			P_rpn = model_rpn.predict_on_batch(X)
 
-			R = roi_helpers.rpn_to_roi(P_rpn[0], P_rpn[1], C, K.image_dim_ordering(), use_regr=True, overlap_thresh=0.7, max_boxes=300)
+			R = roi_helpers.rpn_to_roi(P_rpn[0], P_rpn[1], C, K.common.image_dim_ordering(), use_regr=True, overlap_thresh=0.7, max_boxes=300)
 			# note: calc_iou converts from (x1,y1,x2,y2) to (x,y,w,h) format
 			X2, Y1, Y2, IouS = roi_helpers.calc_iou(R, img_data, C, class_mapping)
 


### PR DESCRIPTION
Some modules like "keras.backend.image_dim_ordering" must change to "keras.backend.common.image_dim_ordering" to work with keras2/tensorflow2 backend
tensorflow.image.resize_image does not work any more, I changed it to tensorflow.image.resize
and some minor isuues to work with keras2/tensorflow2
I test it on ubuntu16.04/tf2.1/keras2.3 and it work